### PR TITLE
Omit environment variables with dots in names

### DIFF
--- a/src/steps/actions/env.ts
+++ b/src/steps/actions/env.ts
@@ -12,7 +12,7 @@ export class EnvironmentStep extends StepI {
       `CommonProgramFiles(x86)`, `ProgramFiles(x86)`
     ];
 
-    const environmentVariables = Object.keys(process.env).filter(key => !ignoredEnvironmentVariables.includes(key));
+    const environmentVariables = Object.keys(process.env).filter(key => !ignoredEnvironmentVariables.includes(key) && !key.includes('.'));
     const commandString = environmentVariables.map(key => `${key}='${process.env[key]}'`).join(` `);
 
     this.log(`Setting environment variables: ${environmentVariables.join(`, `)}`);


### PR DESCRIPTION
This is to fix issues on Azure Pipeline where **agent.jobstatus** environment variable is set during pipeline execution. Variables with dots are causing errors in **env** step